### PR TITLE
Generic get cookie function

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,11 +27,16 @@ yarn add cookie-thief
 ### Google Chrome
 
 ```javascript
-const { getChromeCookie } = require('cookie-thief')
+const { getCookie, Browser } = require('cookie-thief')
 
 // Get a cookie from chrome browser for domain .github.com, searching for cookie named 'dotcom_user'
-const cookie = await getChromeCookie('https://github.com', 'dotcom_user', {
-  profile: 'Default',
+const cookie = await getCookie({
+  browser: Browser.Chrome,
+  url: 'https://github.com',
+  cookieName: 'dotcom_user',
+  options: {
+    profile: 'Default',
+  },
 });
 console.log(cookie);
 // Will be a string if cookie is successfully found
@@ -41,11 +46,16 @@ console.log(cookie);
 ### Firefox
 
 ```javascript
-const { getFirefoxCookie } = require('cookie-thief')
+const { getCookie, Browser } = require('cookie-thief')
 
 // Get a cookie from chrome browser for domain .github.com, searching for cookie named 'dotcom_user'
-const cookie = await getFirefoxCookie('https://github.com', 'dotcom_user', {
-  profile: 'default-release',
+const cookie = await getCookie({
+  browser: Browser.Firefox,
+  url: 'https://github.com',
+  cookieName: 'dotcom_user',
+  options: {
+    profile: 'default-release',
+  },
 });
 console.log(cookie);
 // Will be a string if cookie is successfully found

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cookie-thief",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "Steal browser cookies",
   "main": "./lib/index.js",
   "author": "Alex Kalinin (https://kalinin.uk)",

--- a/src/chrome/index.ts
+++ b/src/chrome/index.ts
@@ -43,6 +43,9 @@ const defaultOptions: GetChromeCookiesOptions = {
   profile: 'Default',
 };
 
+/**
+ * @deprecated Replaced by getCookie
+ */
 export async function getChromeCookie(
   url: string,
   cookieName: string,

--- a/src/firefox/index.ts
+++ b/src/firefox/index.ts
@@ -55,6 +55,10 @@ const defaultOptions: GetFirefoxCookieOptions = {
   profile: 'default-release',
 };
 
+/**
+ * @deprecated Replaced by getCookie
+ */
+
 export async function getFirefoxCookie(
   url: string,
   cookieName: string,

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,38 +5,38 @@ import { assertUnreachable } from './utils';
 export * from './chrome';
 export * from './firefox';
 
-export enum SupportedBrowser {
+export enum Browser {
   Firefox = 'firefox',
   Chrome = 'chrome',
 }
 
 interface BaseGetCookieConfig {
-  browser: SupportedBrowser;
+  browser: Browser;
   url: string;
   cookieName: string;
 }
 
 export interface GetFirefoxCookieConfig extends BaseGetCookieConfig {
-  browser: SupportedBrowser.Firefox;
+  browser: Browser.Firefox;
   options?: Partial<GetFirefoxCookieOptions>;
 }
 
 export interface GetChromeCookieConfig extends BaseGetCookieConfig {
-  browser: SupportedBrowser.Chrome;
+  browser: Browser.Chrome;
   options?: Partial<GetChromeCookiesOptions>;
 }
 
-export function listSupportedBrowsers(): SupportedBrowser[] {
-  return Object.values(SupportedBrowser);
+export function listSupportedBrowsers(): Browser[] {
+  return Object.values(Browser);
 }
 
 export async function getCookie(
   config: GetFirefoxCookieConfig | GetChromeCookieConfig,
 ): Promise<string | undefined> {
   switch (config.browser) {
-    case SupportedBrowser.Firefox:
+    case Browser.Firefox:
       return getFirefoxCookie(config.url, config.cookieName, config.options);
-    case SupportedBrowser.Chrome:
+    case Browser.Chrome:
       return getChromeCookie(config.url, config.cookieName, config.options);
     default:
       return assertUnreachable(config);

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,2 +1,40 @@
+import { GetChromeCookiesOptions, getChromeCookie } from './chrome';
+import { GetFirefoxCookieOptions, getFirefoxCookie } from './firefox';
+import { assertUnreachable } from './utils';
+
 export * from './chrome';
 export * from './firefox';
+
+export enum SupportedBrowser {
+  Firefox = 'firefox',
+  Chrome = 'chrome',
+}
+
+interface BaseGetCookieConfig {
+  browser: SupportedBrowser;
+  url: string;
+  cookieName: string;
+}
+
+export interface GetFirefoxCookieConfig extends BaseGetCookieConfig {
+  browser: SupportedBrowser.Firefox;
+  options?: Partial<GetFirefoxCookieOptions>;
+}
+
+export interface GetChromeCookieConfig extends BaseGetCookieConfig {
+  browser: SupportedBrowser.Chrome;
+  options?: Partial<GetChromeCookiesOptions>;
+}
+
+export async function getCookie(
+  config: GetFirefoxCookieConfig | GetChromeCookieConfig,
+): Promise<string | undefined> {
+  switch (config.browser) {
+    case SupportedBrowser.Firefox:
+      return getFirefoxCookie(config.url, config.cookieName, config.options);
+    case SupportedBrowser.Chrome:
+      return getChromeCookie(config.url, config.cookieName, config.options);
+    default:
+      return assertUnreachable(config);
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -26,6 +26,10 @@ export interface GetChromeCookieConfig extends BaseGetCookieConfig {
   options?: Partial<GetChromeCookiesOptions>;
 }
 
+export function listSupportedBrowsers(): SupportedBrowser[] {
+  return Object.values(SupportedBrowser);
+}
+
 export async function getCookie(
   config: GetFirefoxCookieConfig | GetChromeCookieConfig,
 ): Promise<string | undefined> {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -4,3 +4,7 @@ export function mergeDefaults<T>(defaults: T, options?: Partial<T>): T {
     ...(options || {}),
   };
 }
+
+export function assertUnreachable(x: never): never {
+  return x;
+}

--- a/test/chrome/linux.unit.test.ts
+++ b/test/chrome/linux.unit.test.ts
@@ -1,4 +1,4 @@
-import { getChromeCookie } from '../../src';
+import { Browser, getCookie } from '../../src';
 import { mockPlatform, restorePlatform } from '../util';
 
 jest.mock('better-sqlite3', () =>
@@ -25,7 +25,11 @@ describe('chrome - linux', () => {
   });
 
   it('gets and decrypts linux cookie', async () => {
-    const res = await getChromeCookie('https://someUrl.com', 'foo');
+    const res = await getCookie({
+      browser: Browser.Chrome,
+      url: 'https://someUrl.com',
+      cookieName: 'foo',
+    });
 
     expect(res).toEqual('bar');
   });

--- a/test/firefox.unit.test.ts
+++ b/test/firefox.unit.test.ts
@@ -1,6 +1,6 @@
 import * as sqlite from 'better-sqlite3';
 import { homedir } from 'os';
-import { getFirefoxCookie } from '../src';
+import { getCookie, getFirefoxCookie, Browser } from '../src';
 
 jest.mock('fs', () => ({
   readFileSync: jest.fn().mockReturnValue(`[Profile1]
@@ -41,9 +41,13 @@ describe('firefox get cookie', () => {
     });
 
     it('should fetch cookie correctly', async () => {
-      expect(await getFirefoxCookie('https://some.url', 'some-cookie')).toEqual(
-        'foo',
-      );
+      expect(
+        await getCookie({
+          browser: Browser.Firefox,
+          url: 'https://some.url',
+          cookieName: 'some-cookie',
+        }),
+      ).toEqual('foo');
       expect(sqlite).toHaveBeenCalledWith(
         `${homedir()}/Library/Application Support/Firefox/Profiles/tfhz7h6q.default-release/cookies.sqlite`,
         { fileMustExist: true, readonly: true },
@@ -68,9 +72,13 @@ describe('firefox get cookie', () => {
     });
 
     it('should fetch cookie correctly', async () => {
-      expect(await getFirefoxCookie('https://some.url', 'some-cookie')).toEqual(
-        'foo',
-      );
+      expect(
+        await getCookie({
+          browser: Browser.Firefox,
+          url: 'https://some.url',
+          cookieName: 'some-cookie',
+        }),
+      ).toEqual('foo');
       expect(sqlite).toHaveBeenCalledWith(
         `${homedir()}/.mozilla/firefox/Profiles/tfhz7h6q.default-release/cookies.sqlite`,
         { fileMustExist: true, readonly: true },
@@ -99,9 +107,13 @@ describe('firefox get cookie', () => {
     });
 
     it('should fetch cookie correctly', async () => {
-      expect(await getFirefoxCookie('https://some.url', 'some-cookie')).toEqual(
-        'foo',
-      );
+      expect(
+        await getCookie({
+          browser: Browser.Firefox,
+          url: 'https://some.url',
+          cookieName: 'some-cookie',
+        }),
+      ).toEqual('foo');
       expect(sqlite).toHaveBeenCalledWith(
         `C:/foo/Mozilla/Firefox/Profiles/tfhz7h6q.default-release/cookies.sqlite`,
         { fileMustExist: true, readonly: true },
@@ -127,7 +139,11 @@ describe('firefox get cookie', () => {
 
     it('should throw an error', async () => {
       await expect(
-        getFirefoxCookie('https://someurl.com', 'some-cookie'),
+        getCookie({
+          browser: Browser.Firefox,
+          url: 'https://someurl.com',
+          cookieName: 'some-cookie',
+        }),
       ).rejects.toThrow('Platform freebsd is not supported');
     });
   });

--- a/test/supportedBrowsers.unit.test.ts
+++ b/test/supportedBrowsers.unit.test.ts
@@ -1,0 +1,11 @@
+import { listSupportedBrowsers } from '../src';
+
+describe('list supported browsers', () => {
+  const browsers = listSupportedBrowsers();
+  it('should contain firefox', () => {
+    expect(browsers).toContain('firefox');
+  });
+  it('should contain chrome', () => {
+    expect(browsers).toContain('chrome');
+  });
+});


### PR DESCRIPTION
Added generic getCookie function
Added listSupportedBrowsers function so you can dynamically fetch supported browsers

marked getFirefoxCookie and getChromeCookie as deprecated in favour of new central interface